### PR TITLE
Remove nokogiri platform (`darwin`) from Gemfile.lock (again)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.15.1-x86_64-darwin)
+    nokogiri (1.15.1)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     parallel (1.23.0)
     parser (3.2.2.1)


### PR DESCRIPTION
This was added by release assistant for some reason. I'm going to try to figure out for why, but for now let's remove this again.