### PR TITLE
Bump bundler from 2.2.22 to 2.4.13

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,4 +266,4 @@ RUBY VERSION
    ruby 3.2.0p0
 
 BUNDLED WITH
-   2.2.22
+   2.4.13


### PR DESCRIPTION
Although 2.2.22 is an awesome version number, I am having some bundler-related problems with Nokogiri right now, and I want to see if bumping bundler might fix those issues.