### PR TITLE
Write gemspec Ruby version requirement in a single line

### DIFF
--- a/runger_actions.gemspec
+++ b/runger_actions.gemspec
@@ -13,8 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/davidrunger/runger_actions'
   spec.license       = 'MIT'
 
-  ruby_version = File.read('.ruby-version').rstrip
-  spec.required_ruby_version = Gem::Requirement.new(">= #{ruby_version}")
+  spec.required_ruby_version = Gem::Requirement.new(">= #{File.read('.ruby-version').rstrip}")
 
   spec.metadata['rubygems_mfa_required'] = 'true'
   spec.metadata['homepage_uri'] = spec.homepage


### PR DESCRIPTION
This makes it easier to see what's happening when grepping for this single line, and makes it a bit easier to update via CLI commands.