### PR TITLE
Change references to "master" branch to "main"

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,7 +6,7 @@ on:
     - '*'
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Rename primary branch from `master` to `main`
 
 ## v0.19.2 (2023-05-30)
 ### Changed
@@ -157,7 +157,7 @@ end
 ### Breaking changes
 - Update `shaped` (which is used for param validation) from version 0.2.1 to 0.3.0, which has
   breaking changes. For more details, see the [`shaped`
-  changelog](https://github.com/davidrunger/shaped/blob/master/CHANGELOG.md#030---2020-06-18).
+  changelog](https://github.com/davidrunger/shaped/blob/main/CHANGELOG.md#030---2020-06-18).
 - For `requires`, _all_ type/shape descriptions (i.e. arguments `[1..]`) are now passed through the
   `Shaped::Shape(...)` constructor method. (In most cases, this change will not have any effect,
   because in most cases the type/shape description was a single class, and this change has no effect

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![codecov](https://codecov.io/gh/davidrunger/runger_actions/branch/master/graph/badge.svg)](https://codecov.io/gh/davidrunger/runger_actions)
+[![codecov](https://codecov.io/gh/davidrunger/runger_actions/branch/main/graph/badge.svg)](https://codecov.io/gh/davidrunger/runger_actions)
 ![GitHub tag (latest SemVer pre-release)](https://img.shields.io/github/v/tag/davidrunger/runger_actions?include_prereleases)
 
 # RungerActions
@@ -645,7 +645,7 @@ own itch and for the sake of exploring this problem space a little bit.
 
 I am actively using this gem in the small Rails application that hosts my personal website and apps;
 you can check out its [`app/actions/`
-directory](https://github.com/davidrunger/david_runger/tree/master/app/actions) if you are
+directory](https://github.com/davidrunger/david_runger/tree/main/app/actions) if you are
 interested in seeing some real-world use cases.
 
 # Development

--- a/runger_actions.gemspec
+++ b/runger_actions.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/davidrunger/runger_actions'
   spec.metadata['changelog_uri'] =
-    'https://github.com/davidrunger/runger_actions/blob/master/CHANGELOG.md'
+    'https://github.com/davidrunger/runger_actions/blob/main/CHANGELOG.md'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
I have renamed the "master" branch in GitHub to "main", so we need to update these references to reflect that change.

Also, update the branch referenced in some other projects from `master` to `main`.