### PR TITLE
Update gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,9 +121,9 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
-    minitest (5.23.1)
+    minitest (5.24.0)
     mutex_m (0.2.0)
-    net-imap (0.4.13)
+    net-imap (0.4.14)
       date
       net-protocol
     net-pop (0.1.2)
@@ -149,7 +149,7 @@ GEM
     psych (5.1.2)
       stringio
     racc (1.8.0)
-    rack (3.1.3)
+    rack (3.1.4)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -193,7 +193,7 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.9)
       io-console (~> 0.5)
-    rexml (3.3.0)
+    rexml (3.3.1)
       strscan
     rouge (4.3.0)
     rspec (3.13.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,7 @@ GEM
       date
       net-protocol
     net-pop (0.1.2)
+      net-protocol
     net-protocol (0.2.2)
       timeout
     net-smtp (0.5.0)


### PR DESCRIPTION
`bundle update`

Also, add `net-protocol` dependency of `net-pop` in `Gemfile.lock`, via:

```
gem uninstall net-pop
gem install net-pop
bundle update net-pop
```

Many thanks to https://stackoverflow.com/a/78620570/4009384 for the solution!
Bug: https://github.com/ruby/net-pop/issues/ 26
Fix: https://github.com/ruby/ruby/pull/ 11006

This should fix the error we were getting on [this build](https://github.com/davidrunger/runger_actions/actions/runs/9672980386/job/26686187510?pr=570).

```
Downloading net-pop-0.1.2 revealed dependencies not in the API or the lockfile
(net-protocol (>= 0)).
Running `bundle update net-pop` should fix the problem.
Error: The process '/opt/hostedtoolcache/Ruby/3.3.3/x64/bin/bundle' failed with exit code 34
```