### PR TITLE
Loosen 'shaped' dependency spec from '< 0.14' to '< 1.0'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Relaxed `shaped` gemspec requirement to `< 1.0`.
 
 ## v0.22.0 (2024-06-28)
 - Enforce only major and minor parts of required Ruby version (loosening the required Ruby version from 3.3.3 to 3.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     runger_actions (0.22.1.alpha)
       memo_wise (>= 1.7, < 2)
       rails (>= 6, < 8)
-      shaped (>= 0.9, < 0.14)
+      shaped (>= 0.9, < 1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/runger_actions.gemspec
+++ b/runger_actions.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('memo_wise', '>= 1.7', '< 2')
   spec.add_dependency('rails', '>= 6', '< 8')
-  spec.add_dependency('shaped', '>= 0.9', '< 0.14')
+  spec.add_dependency('shaped', '>= 0.9', '< 1.0')
 end


### PR DESCRIPTION
This will make it so we don't need to update this gem every time that a new version of `shaped` is released.