### PR TITLE
[gemspec] Remove upper bounds on versions for all dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Remove upper bounds on versions for all dependencies
 
 ## v0.23.0 (2024-09-05)
 - Relaxed `shaped` gemspec requirement to `< 1.0`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,9 @@ PATH
   remote: .
   specs:
     runger_actions (0.23.1.alpha)
-      memo_wise (>= 1.7, < 2)
-      rails (>= 6, < 8)
-      shaped (>= 0.9, < 1.0)
+      memo_wise (>= 1.7)
+      rails (>= 6)
+      shaped (>= 0.9)
 
 GEM
   remote: https://rubygems.org/

--- a/runger_actions.gemspec
+++ b/runger_actions.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
     end
   spec.require_paths = ['lib']
 
-  spec.add_dependency('memo_wise', '>= 1.7', '< 2')
-  spec.add_dependency('rails', '>= 6', '< 8')
-  spec.add_dependency('shaped', '>= 0.9', '< 1.0')
+  spec.add_dependency('memo_wise', '>= 1.7')
+  spec.add_dependency('rails', '>= 6')
+  spec.add_dependency('shaped', '>= 0.9')
 end


### PR DESCRIPTION
Let's optimistically assume that all future versions will be compatible. We can add restrictions if that turns out not to be the case. The upside of this change is that we don't have to make changes in this gem when new versions of these dependencies are released.