### PR TITLE
Remove manual require of the gem itself

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,8 +17,6 @@ end
 require 'bundler/setup'
 Bundler.require(:default, :test)
 
-require 'runger_actions'
-
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
This is not needed, because we have `Bundler.require(:default, :test)`, and we have `gemspec` in the default group of the `Gemfile`.